### PR TITLE
Add cinemachine dependency

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.unity.ads": "2.0.8",
     "com.unity.analytics": "3.2.3",
+    "com.unity.cinemachine": "2.6.3",
     "com.unity.collab-proxy": "1.2.15",
     "com.unity.package-manager-ui": "2.0.8",
     "com.unity.postprocessing": "2.3.0",


### PR DESCRIPTION
This is now required for VRCSDK3 to compile.