### PR TITLE
Playlist shuffling fix

### DIFF
--- a/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
+++ b/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
@@ -985,10 +985,10 @@ namespace UdonSharp.Video
             {
                 Random.InitState(_shuffleSeed);
 
-                int n = playlist.Length - 1;
-                for (int i = 0; i < n; ++i)
+                for (int i = 0; i < playlist.Length - 1; ++i)
                 {
-                    int r = Random.Range(i + 1, n);
+                    int r = Random.Range(i, playlist.Length);
+                    if (i == r) { continue; }
                     VRCUrl flipVal = playlist[r];
                     playlist[r] = playlist[i];
                     playlist[i] = flipVal;


### PR DESCRIPTION
Simply put, playlist shuffling is done wrong.

2 items will always be reversed.
3 items will always be shuffled into the same order, 123 -> 231
4 items will be shuffled into 1 of 2 possible orders.
etc.

So I've fixed it.

(the `continue` isn't necessary)