### PR TITLE
Fix  UdonSharp compile errors when Unity project contains editor scripts with namespace `****.Editor`.

### DIFF
--- a/Assets/USharpVideo/Examples/Scripts/ExampleSceneFixup/SceneLightmapFixer.cs
+++ b/Assets/USharpVideo/Examples/Scripts/ExampleSceneFixup/SceneLightmapFixer.cs
@@ -193,7 +193,7 @@ namespace UdonSharp.Video.Internal
     }
 
     [CustomEditor(typeof(SceneLightmapFixer))]
-    public class SceneLightmapFixerEditor : Editor
+    public class SceneLightmapFixerEditor : UnityEditor.Editor
     {
         public override void OnInspectorGUI()
         {

--- a/Assets/USharpVideo/Scripts/UI/UIStyler.cs
+++ b/Assets/USharpVideo/Scripts/UI/UIStyler.cs
@@ -152,7 +152,7 @@ namespace UdonSharp.Video.UI
 
 #if UNITY_EDITOR
     [CustomEditor(typeof(UIStyler))]
-    internal class UIStylerEditor : Editor
+    internal class UIStylerEditor : UnityEditor.Editor
     {
         private SerializedProperty colorStyleProperty;
 


### PR DESCRIPTION
This PR fixes:
UdonSharp shows a compile error:

> [UdonSharp] Assets/USharpVideo/Scripts/UI/UIStyler.cs(155,37): error CS0118: 'Editor' is a namespace but is used like a type

when there is an editor script with a namespace `****.Editor`. This happens even when that editor script belongs to an asmdef with `auto referenced` disabled.