### PR TITLE
Fix: properly set initial slider state if `defaultStreamMode`

### DIFF
--- a/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
+++ b/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
@@ -177,8 +177,9 @@ namespace UdonSharp.Video
                     SetPlayerMode(PLAYER_MODE_AVPRO);
                     _nextPlaylistIndex = 0; // SetPlayerMode sets this to -1, but we want to be able to keep it intact so reset to 0
 
-                    var syncController = GetComponentInChildren<SyncModeController>();
-                    syncController.SetStreamVisual();
+                    foreach (var syncController in GetComponentsInChildren<SyncModeController>()) {
+                        syncController.SetStreamVisual();
+                    }
                 }
 
                 _shuffleSeed = Random.Range(0, 10000);

--- a/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
+++ b/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
@@ -176,6 +176,9 @@ namespace UdonSharp.Video
                 {
                     SetPlayerMode(PLAYER_MODE_AVPRO);
                     _nextPlaylistIndex = 0; // SetPlayerMode sets this to -1, but we want to be able to keep it intact so reset to 0
+
+                    var syncController = GetComponentInChildren<SyncModeController>();
+                    syncController.SetStreamVisual();
                 }
 
                 _shuffleSeed = Random.Range(0, 10000);


### PR DESCRIPTION
This is a quick and dirty fix that just calls the code that _should_ be getting called by SetPlayerMode. Didn't have time to look into why it doesn't.