### PR TITLE
Fix screen initialization and standby texture

### DIFF
--- a/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
+++ b/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
@@ -1333,8 +1333,13 @@ namespace UdonSharp.Video
             VideoPlayerManager manager = GetVideoManager();
             newControlHandler.SetVolume(manager.GetVolume());
             newControlHandler.SetMuted(manager.IsMuted());
+
+            if (IsUsingUnityPlayer())
+                newControlHandler.SetToVideoPlayerMode();
+            else
+                newControlHandler.SetToStreamPlayerMode();
         }
-        
+
         public void UnregisterControlHandler(VideoControlHandler controlHandler)
         {
             if (_registeredControlHandlers == null)

--- a/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
+++ b/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
@@ -1497,7 +1497,7 @@ namespace UdonSharp.Video
 
             foreach (VideoScreenHandler handler in _registeredScreenHandlers)
             {
-                if (handler)
+                if (handler && handler.GetVideoTexture() != renderTexture)
                 {
                     handler.UpdateVideoTexture(renderTexture, IsUsingAVProPlayer());
                 }

--- a/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
+++ b/Assets/USharpVideo/Scripts/USharpVideoPlayer.cs
@@ -1447,6 +1447,8 @@ namespace UdonSharp.Video
                     return;
             }
 
+            newScreenHandler.UpdateVideoTexture(_lastAssignedRenderTexture, IsUsingAVProPlayer());
+
             VideoScreenHandler[] newControlHandlers = new VideoScreenHandler[_registeredScreenHandlers.Length + 1];
             _registeredScreenHandlers.CopyTo(newControlHandlers, 0);
             _registeredScreenHandlers = newControlHandlers;

--- a/Assets/USharpVideo/Scripts/Utility/VideoScreenHandler.cs
+++ b/Assets/USharpVideo/Scripts/Utility/VideoScreenHandler.cs
@@ -31,15 +31,9 @@ namespace UdonSharp.Video
         private Renderer targetRenderer;
         private Texture lastRenderTexture;
 
-        private void Start()
-        {
-            targetRenderer = GetComponent<Renderer>();
-
-            OnEnable();
-        }
-
         private void OnEnable()
         {
+            targetRenderer = GetComponent<Renderer>();
             SetSourceVideoPlayer(sourceVideoPlayer);
         }
 

--- a/Assets/USharpVideo/Scripts/Utility/VideoScreenHandler.cs
+++ b/Assets/USharpVideo/Scripts/Utility/VideoScreenHandler.cs
@@ -51,9 +51,6 @@ namespace UdonSharp.Video
 
         public void UpdateVideoTexture(Texture renderTexture, bool isAVPro)
         {
-            if (renderTexture == lastRenderTexture)
-                return;
-
             if (targetRenderer)
             {
                 Material rendererMat;


### PR DESCRIPTION
This PR fixes screens not being fully initialized when attaching themselves to the player, and the standby texture not being set.

Closes #104 
Closes #105 
